### PR TITLE
Improved documentation and handles videos with spaces in the filename

### DIFF
--- a/Potty-Boom-Boom-watchdog.sh
+++ b/Potty-Boom-Boom-watchdog.sh
@@ -2,6 +2,6 @@
 
 while true
 do
-        myrandomfile=$(find "~/Potty-Boom-Boom/Files/" -type f | shuf -n 1)
+        myrandomfile=$(find ~/Potty-Boom-Boom/Files/ -type f | shuf -n 1)
         omxplayer -b "${myrandomfile}"
 done

--- a/Potty-Boom-Boom-watchdog.sh
+++ b/Potty-Boom-Boom-watchdog.sh
@@ -2,6 +2,6 @@
 
 while true
 do
-        myrandomfile=$(find ~/Potty-Boom-Boom/Files/ -type f | shuf -n 1)
-        omxplayer -b ${myrandomfile}
+        myrandomfile=$(find "~/Potty-Boom-Boom/Files/" -type f | shuf -n 1)
+        omxplayer -b "${myrandomfile}"
 done

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Potty-Boom-Boom
-An raspian based Toilet-media-center used at EH16 to entertain and speed up toilet usage
+A raspian based Toilet-media-center used at EH16 to entertain and speed up toilet usage
 
 HOWTO:
  - Deploy Raspian-Lite[1] on a SD Card of your joice (If the Potty-Boom-Boom is used without network and remote-storage choose a big SD-Card 8GB+) 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,12 @@ An raspian based Toilet-media-center used at EH16 to entertain and speed up toil
 
 HOWTO:
  - Deploy Raspian-Lite[1] on a SD Card of your joice (If the Potty-Boom-Boom is used without network and remote-storage choose a big SD-Card 8GB+) 
- - Run raspi-config and choose the menupoint to extend the root-filesystem and reboot the system (Important, otherwise space will be filled up during install)
- - Start your new Potty-Boom-Boom device and connect to it.
+ - Change the password for the `pi` user with `passwd`.
+ - Run `raspi-config` and do the following steps
+	 - 	Select `9 Advanced Options` then chose `A3 Memory Split` and make sure that you grant at least 64MB to the GPU.
+	 -  Select `9 Advanced Options` then chose `A9 Audio` and verify that your audio output is set correctly whether you want to use HDMI audio or the 3.5mm jack.
+	 -  Select `1 Expand Filesystem`, let it do its magic and reboot the system. This is important, otherwise installation will fail due to lack of freespace on the SD card.
+ - After the restart connect via SSH do the installation.
  - Install git, checkout the Boom-Boom-izer.sh and execute it.
 ```
 sudo apt update && sudo apt -y install git
@@ -12,11 +16,7 @@ git clone https://github.com/AMD1212/potty-boom-boom.git /tmp/potty-boom-boom
 sudo sh /tmp/potty-boom-boom/Boom-Boom-izer.sh
 ```
  - Place your mp4 encoded videos in the /home/pi/Potty-Boom-Boom/Files/
+ - Finally reboot the Raspberry Pi to have it autostart.
  - Boom Boom!
-
-
-
-
-
 
 [1] https://www.raspberrypi.org/downloads/raspbian/


### PR DESCRIPTION
Improved the documentation so people know to check for VRAM split size and audio output in `raspi-config`.
Playback now handles video files with spaces more gracefully. Less cleanup needed after fetching video files with `youtube-dl`.
