### PR TITLE
properly pseudo-randomizes video files

### DIFF
--- a/Potty-Boom-Boom-watchdog.sh
+++ b/Potty-Boom-Boom-watchdog.sh
@@ -1,7 +1,16 @@
 #/bin/sh
 
+DIRECTORY="$HOME/Potty-Boom-Boom/Files"
+PLAYER="omxplayer -b"
+
+unset old
 while true
 do
-        myrandomfile=$(find ~/Potty-Boom-Boom/Files/ -type f | shuf -n 1)
-        omxplayer -b "${myrandomfile}"
+	find "$DIRECTORY" -type f | shuf | while read one; do
+		if [ "$one" != "$old" ]; then 
+			echo "... boom-booming '$one'"
+			$PLAYER "$one"
+			old=$one
+		fi
+	done
 done


### PR DESCRIPTION
random selection on each video selection can result in the same video played
in sequence or some videos more often. Instead, only shuffle the video list
once before playing and skip immediate duplicates (inbetween lists).
